### PR TITLE
add theme support & provide a night theme

### DIFF
--- a/css/themes/night/github-markdown.css
+++ b/css/themes/night/github-markdown.css
@@ -600,7 +600,7 @@ td,th {
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
-  background-color: #f7f7f7;
+  background-color: #333;
   border-radius: 3px;
 }
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="Content-Language" content="en">
+  <!-- theme stylesheets are dynamic loaded in index.js, according to 'theme' param -->
+  <!-- <link rel="stylesheet" type="text/css" href="/css/github-syntax-highlight.css"> -->
+  <!-- <link rel="stylesheet" type="text/css" href="/css/github-markdown.css"> -->
   <link rel="stylesheet" type="text/css" href="/css/mjpage-html.css">
   <style>
     .markdown-body {
@@ -24,13 +27,6 @@
   <script src="/node_modules/mermaid/dist/mermaid.min.js"></script>
   <script src="/socket.io/socket.io.min.js"></script>
   <script src="/index.js"></script>
-  <script type="text/javascript">
-      // dynamic load style according to *theme* params
-      let theme = getUrlParameter("theme");
-      let themePath = theme ? "themes/"+theme : "";
-      loadStyle("/css/"+themePath+ "/github-markdown.css");
-      loadStyle("/css/"+themePath+ "/github-syntax-highlight.css");
-  </script>
 </head>
 <body>
   <div class="container">

--- a/index.js
+++ b/index.js
@@ -87,3 +87,13 @@ function getUrlParameter(sParam){
     }
   }
 }
+
+
+// dynamic load style according to *theme* params
+window.onload = function(){
+   let theme = getUrlParameter("theme");
+   let themePath = theme ? "themes/"+theme : "";
+   loadStyle("/css/"+themePath+ "/github-markdown.css");
+   loadStyle("/css/"+themePath+ "/github-syntax-highlight.css");
+}
+

--- a/src/cli.js
+++ b/src/cli.js
@@ -269,7 +269,7 @@ function onListening() {
     }
   }
   let cmd = argv.browser + ' http://localhost:' + argv.port + '/?';
-  // add theme param if absent
+  // add theme param if present
   if (argv.theme){
      cmd += 'theme=' + argv.theme;
   }


### PR DESCRIPTION
1、add a 'theme'  param to http-server, to dynamic rendering preview-page style
2、provide a 'night' style

for example: 
![image](https://user-images.githubusercontent.com/1983142/170471537-54998e54-5c84-4118-9f31-072e66dba80f.png)
>  the preview page in 'night' theme according to request param '?theme=night' 

![image](https://user-images.githubusercontent.com/1983142/170471510-5f65ce24-f06d-4df3-8641-94d5f241eeba.png)

